### PR TITLE
Change shell.nix to also use poetry2nix.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,14 @@
 { pkgs ? import <nixpkgs> {} }:
 
-pkgs.mkShell {
+let
+  poetryEnv = pkgs.poetry2nix.mkPoetryEnv {
+    projectDir = ./.;
+  };
+in pkgs.mkShell {
 
   buildInputs = [
-    pkgs.python3
     pkgs.poetry
+    poetryEnv
   ];
 
 }


### PR DESCRIPTION
This ensures the correct python verison is available.
It also makes all dependencies and dev-dependencies available in the shell.